### PR TITLE
Fix spell check failure by using en-US variant of word

### DIFF
--- a/f3dexporter/f3dexporter.py
+++ b/f3dexporter/f3dexporter.py
@@ -1,5 +1,5 @@
 #
-# licenced into the public domain by https://github.com/aconz2/Fusion360Exporter
+# licensed into the public domain by https://github.com/aconz2/Fusion360Exporter
 # add as a "script" in fusion 360.
 #
 


### PR DESCRIPTION
For the sake of consistency, the [**codespell**](https://github.com/codespell-project/codespell) tool used to check spelling in the project files is configured to use en-US spellings.

The word licenced was added (https://github.com/codespell-project/codespell/commit/168fd92101b70da531a79400e0620c45b9a76dcc) to the tool's dictionary of non-en-US variants in the latest release. This addition caused the spell check to begin to fail since the word is present in the project's files:

https://github.com/107-systems/l3xz-hw-pan-tilt-head/actions/runs/6860819059/job/18655306156#step:4:17

```text
Error: ./f3dexporter/f3dexporter.py:2: licenced ==> licensed
Codespell found one or more problems
```

The chosen solution is to change the to using the en-US variant of the word: "licensed".

The alternative would be to adjust the configuration of codespell. Excluding files altogether is the best approach in cases where they are maintained externally. I chose not to take that approach because I see that the file in this repository contains modifications maintained here (including another spelling adjustment) rather than being a exact copy of the upstream source file.